### PR TITLE
GitHub Integrations Improvements

### DIFF
--- a/apps/api/src/lib/helpers/capture-errors.ts
+++ b/apps/api/src/lib/helpers/capture-errors.ts
@@ -8,18 +8,23 @@ export const captureErrors: Middleware = async (_req, res, next) => {
     // middleware and the API route handler
     await next();
   } catch (error) {
-    Sentry.captureException(error);
-
     if (error instanceof HttpError) {
       res.status(error.statusCode).json({ message: error.message, error });
       return;
     }
 
-    if (error instanceof Error) {
-      res.status(400).json({ message: error.message, error });
-      return;
-    }
+    /**
+     * TODO: Handle other errors here for better error messages.
+     * Eg. Zod errors
+     */
 
-    res.status(400).json({ message: "Something went wrong", error });
+    /**
+     * If we get here, it means that we have an unhandled error
+     */
+    Sentry.captureException(error);
+
+    res.status(500).json({
+      message: `Unhandled error of type '${typeof error}'. Please reach out for our customer support.`,
+    });
   }
 };

--- a/apps/api/src/lib/helpers/default-handler.ts
+++ b/apps/api/src/lib/helpers/default-handler.ts
@@ -42,10 +42,5 @@ export const defaultHandler =
       return;
     }
 
-    try {
-      await handler(req, res);
-    } catch (error) {
-      console.error(error);
-      res.status(500).json({ message: "Something went wrong" });
-    }
+    await handler(req, res);
   };

--- a/apps/api/src/lib/helpers/default-responder.ts
+++ b/apps/api/src/lib/helpers/default-responder.ts
@@ -13,13 +13,7 @@ export function defaultResponder<T>(f: Handle<T>) {
     req: NextApiRequestExtension,
     res: NextApiResponseExtension
   ) => {
-    try {
-      const result = (await f(req, res)) as unknown;
-      if (result) res.json(result);
-    } catch (err) {
-      console.error(err);
-      res.statusCode = err.statusCode;
-      res.json({ message: err.message });
-    }
+    const result = (await f(req, res)) as unknown;
+    if (result) res.json(result);
   };
 }

--- a/apps/api/src/lib/normalizedGitProviders/compare.ts
+++ b/apps/api/src/lib/normalizedGitProviders/compare.ts
@@ -27,6 +27,14 @@ export async function compare(
    * Can only have githubIntegration or gitlabIntegration, not both
    */
   if (workspace.githubIntegration) {
+    if (!workspace.githubIntegration.installationId) {
+      res.status(400).json({
+        error: "The GitHub integration is pending approval",
+      });
+
+      return;
+    }
+
     const octokit = await getOctokit(
       workspace.githubIntegration.installationId
     );

--- a/apps/api/src/lib/normalizedGitProviders/content.ts
+++ b/apps/api/src/lib/normalizedGitProviders/content.ts
@@ -17,6 +17,14 @@ export async function contents(
    * Can only have githubIntegration or gitlabIntegration, not both
    */
   if (workspace.githubIntegration) {
+    if (!workspace.githubIntegration.installationId) {
+      res.status(400).json({
+        error: "The GitHub integration is pending approval",
+      });
+
+      return;
+    }
+
     const octokit = await getOctokit(
       workspace.githubIntegration.installationId
     );

--- a/apps/api/src/pages/api/git/issue-comments/_get.ts
+++ b/apps/api/src/pages/api/git/issue-comments/_get.ts
@@ -21,7 +21,7 @@ async function handler({
     });
   }
 
-  if (!workspace.githubIntegration) {
+  if (!workspace.githubIntegration?.installationId) {
     throw new HttpError({
       message: "You must first setup your GitHub integration.",
       statusCode: 400,

--- a/apps/api/src/pages/api/git/issue-comments/_post.ts
+++ b/apps/api/src/pages/api/git/issue-comments/_post.ts
@@ -28,6 +28,13 @@ async function handler({
     });
   }
 
+  if (!workspace.githubIntegration.installationId) {
+    throw new HttpError({
+      message: "The GitHub integration is pending approval.",
+      statusCode: 400,
+    });
+  }
+
   const octokit = await getOctokit(workspace.githubIntegration.installationId);
 
   const comment = await octokit.rest.issues
@@ -45,8 +52,6 @@ async function handler({
         statusCode: 500,
       });
     });
-
-  console.log(222222, comment);
 
   return comment.data;
 }

--- a/apps/api/src/pages/api/git/review-comments/_get.ts
+++ b/apps/api/src/pages/api/git/review-comments/_get.ts
@@ -26,6 +26,13 @@ async function handler({
     });
   }
 
+  if (!workspace.githubIntegration.installationId) {
+    throw new HttpError({
+      message: "The GitHub integration is pending approval.",
+      statusCode: 400,
+    });
+  }
+
   const octokit = await getOctokit(workspace.githubIntegration.installationId);
 
   const comments = await octokit

--- a/apps/api/src/pages/api/git/review-comments/_post.ts
+++ b/apps/api/src/pages/api/git/review-comments/_post.ts
@@ -26,6 +26,13 @@ async function handler({
     });
   }
 
+  if (!workspace.githubIntegration.installationId) {
+    throw new HttpError({
+      message: "The GitHub integration is pending approval.",
+      statusCode: 400,
+    });
+  }
+
   const octokit = await getOctokit(workspace.githubIntegration.installationId);
 
   const comments = await octokit.rest.pulls

--- a/apps/app/src/app/(authenticated)/[workspace]/integrations/github-button.tsx
+++ b/apps/app/src/app/(authenticated)/[workspace]/integrations/github-button.tsx
@@ -42,7 +42,11 @@ export function GitHubButton({ workspace }: GitHubButtonProps) {
         window.open(installationUrl);
       }}
     >
-      {workspace.githubIntegration ? "Linked" : "Link account"}
+      {workspace.githubIntegration
+        ? workspace.githubIntegration.status === "pending"
+          ? "Pending approval"
+          : "Linked"
+        : "Link account"}
     </Button>
   );
 }

--- a/apps/app/src/app/(authenticated)/[workspace]/integrations/github-button.tsx
+++ b/apps/app/src/app/(authenticated)/[workspace]/integrations/github-button.tsx
@@ -43,7 +43,7 @@ export function GitHubButton({ workspace }: GitHubButtonProps) {
       }}
     >
       {workspace.githubIntegration
-        ? workspace.githubIntegration.status === "pending"
+        ? !workspace.githubIntegration.installationId
           ? "Pending approval"
           : "Linked"
         : "Link account"}

--- a/apps/app/src/app/(authenticated)/[workspace]/page.tsx
+++ b/apps/app/src/app/(authenticated)/[workspace]/page.tsx
@@ -96,7 +96,7 @@ export default async function Workspace({
               <div className="flex items-start justify-between py-6">
                 <div className="flex gap-4">
                   <div className="flex items-center justify-center w-8 h-8 m-0 rounded-full bg-amber-100 text-amber-800">
-                    {workspace.githubIntegration ||
+                    {workspace.githubIntegration?.installationId ||
                     workspace.gitlabIntegration ? (
                       <CheckIcon className="h-5" />
                     ) : (

--- a/apps/app/src/app/(authenticated)/new/step-2.tsx
+++ b/apps/app/src/app/(authenticated)/new/step-2.tsx
@@ -36,7 +36,7 @@ export function Step2() {
             }}
           >
             {workspace.githubIntegration
-              ? workspace.githubIntegration.status === "pending"
+              ? !workspace.githubIntegration.installationId
                 ? "Pending approval"
                 : "Linked"
               : "Link account"}

--- a/apps/app/src/app/(authenticated)/new/step-2.tsx
+++ b/apps/app/src/app/(authenticated)/new/step-2.tsx
@@ -35,7 +35,11 @@ export function Step2() {
               window.open(installationUrl);
             }}
           >
-            {workspace.githubIntegration ? "Linked" : "Link account"}
+            {workspace.githubIntegration
+              ? workspace.githubIntegration.status === "pending"
+                ? "Pending approval"
+                : "Linked"
+              : "Link account"}
           </Button>
         </div>
 

--- a/apps/app/src/app/api/installation-callback/get-octokit.ts
+++ b/apps/app/src/app/api/installation-callback/get-octokit.ts
@@ -1,0 +1,39 @@
+import { Octokit } from "octokit";
+import { env } from "~/env.mjs";
+
+export async function getOctokit(code: string) {
+  const queryParams = new URLSearchParams({
+    code,
+    client_id: env.GITHUB_CLIENT_ID,
+    client_secret: env.GITHUB_CLIENT_SECRET,
+  }).toString();
+
+  /**
+   * Exchange the code for an access token.
+   */
+  const resp = await fetch(
+    `https://github.com/login/oauth/access_token?${queryParams}`,
+    {
+      method: "POST",
+      headers: {
+        Accept: "application/json",
+      },
+    }
+  );
+
+  if (!resp.ok) {
+    console.log(
+      "Installation error. Failed to get access token with: ",
+      resp.status,
+      resp.statusText
+    );
+    // redirect(`${url}?installation_error=1`);
+    throw new Error("Failed to get access token");
+  }
+
+  const { access_token: auth } = await resp.json();
+
+  return new Octokit({
+    auth,
+  });
+}

--- a/apps/app/src/app/api/installation-callback/route.ts
+++ b/apps/app/src/app/api/installation-callback/route.ts
@@ -1,20 +1,22 @@
 import { z } from "zod";
 import { db } from "@floe/db";
 import { HttpError } from "@floe/lib/http-error";
+import type { NextRequest } from "next/server";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
+import { env } from "~/env.mjs";
 import { authOptions } from "~/server/auth";
 import { parseGitHubInstallationCallback } from "~/lib/features/github-installation";
 import { getOctokit } from "./get-octokit";
 
 const schema = z.object({
   code: z.string(),
-  state: z.string().optional(),
-  installationId: z.coerce.number().optional(),
+  state: z.string().nullish(),
+  installationId: z.coerce.number().nullish(),
   setupAction: z.enum(["install", "request"]),
 });
 
-const handler = async (req) => {
+const handler = async (req: NextRequest) => {
   const searchParams = req.nextUrl.searchParams;
 
   const { code, state, installationId, setupAction } = schema.parse({
@@ -24,13 +26,12 @@ const handler = async (req) => {
     installationId: searchParams.get("installation_id"),
   });
 
+  const session = await getServerSession(authOptions);
   /**
    * Handle request install action.
    * This happens when a GitHub app needs to go through approval.
    */
   if (setupAction === "request") {
-    const session = await getServerSession(authOptions);
-
     if (!session) {
       throw new HttpError({
         message: "Unauthorized",
@@ -82,12 +83,23 @@ const handler = async (req) => {
     redirect(url);
   }
 
-  return;
-
   /**
+   * INSTALL ACTION
    * If not request, then it's an install action.
    */
+
+  /**
+   * If there is state, this was triggered from a workflow where the approval
+   * flow was not required (eg. when the user is the owner)
+   */
   if (state) {
+    if (!session) {
+      throw new HttpError({
+        message: "Unauthorized",
+        statusCode: 401,
+      });
+    }
+
     const { id, slug, path, url } = parseGitHubInstallationCallback(state);
 
     if (!path || !slug || !id) {
@@ -118,37 +130,95 @@ const handler = async (req) => {
       );
       redirect(`${url}?installation_error=1`);
     }
-  }
 
-  /**
-   * Set the githubIntegrationId on the workspace
-   */
-  try {
-    await db.githubIntegration.upsert({
-      where: {
-        workspaceId: id,
-        workspace: {
-          members: {
-            some: {
-              userId: session.user.id,
+    /**
+     * Set the githubIntegrationId on the workspace
+     */
+    try {
+      await db.githubIntegration.upsert({
+        where: {
+          workspaceId: id,
+          workspace: {
+            members: {
+              some: {
+                userId: session.user.id,
+              },
             },
           },
         },
-      },
-      create: {
-        workspaceId: id,
-        installationId,
-      },
-      update: {
-        installationId,
-      },
-    });
-  } catch (e) {
-    console.log("Installation error. Failed to update workspace with: ", e);
-    redirect(`${url}?installation_error=1`);
+        create: {
+          workspaceId: id,
+          installationId,
+          status: "installed",
+        },
+        update: {
+          installationId,
+          status: "installed",
+        },
+      });
+    } catch (e) {
+      console.log("Installation error. Failed to update workspace with: ", e);
+      redirect(`${url}?installation_error=1`);
+    }
+
+    redirect(url);
   }
 
-  redirect(url);
+  /**
+   * If there is no state, this was triggered from a workflow where the approval
+   * flow was required (eg. when the user is not the owner).
+   *
+   * This workflow is not supported by GitHub yet:
+   * https://github.com/orgs/community/discussions/42351 SO, we cannot
+   * programtically set the installation. Instead, we can just direct the
+   * installer (a GitHub admin) to a confirmation page which includes an email
+   * link to request access. I then need to manually set the installation and
+   * set the status to "installed".
+   */
+  if (installationId) {
+    const octokit = await getOctokit(code);
+    const installation = await octokit.request(
+      "GET /app/installations/{installation_id}",
+      {
+        installation_id: installationId,
+        headers: {
+          "X-GitHub-Api-Version": "2022-11-28",
+        },
+      }
+    );
+
+    /**
+     * Email
+     */
+    const email = "contact@floe.dev";
+
+    /**
+     * Let me know that someone has requested an installation.
+     */
+    await fetch("https://api.sendgrid.com/v3/mail/send", {
+      // The body format will vary depending on provider, please see their documentation
+      // for further details.
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email }] }],
+        from: { email: "noreply@floe.dev" },
+        subject: "📥 Installation Request",
+        content: [
+          {
+            type: "text/plain",
+            value: `Installation request for\nInstallation ID:${installationId}\nGitHub Account Name:${installation.data.account?.name}`,
+          },
+        ],
+      }),
+      headers: {
+        // Authentication will also vary from provider to provider, please see their docs.
+        Authorization: `Bearer ${env.SENDGRID_API}`,
+        "Content-Type": "application/json",
+      },
+      method: "POST",
+    });
+
+    redirect("/installation-confirmed");
+  }
 };
 
 export { handler as GET, handler as POST };

--- a/apps/app/src/app/installation-confirmed/page.tsx
+++ b/apps/app/src/app/installation-confirmed/page.tsx
@@ -2,13 +2,13 @@ import { CheckCircleIcon } from "@heroicons/react/24/solid";
 
 export default function Page() {
   return (
-    <div className="px-4 prose prose-zinc sm:w-full sm:max-w-[360px] mx-auto pt-60 flex flex-col items-center">
+    <div className="px-4 prose prose-zinc sm:w-full sm:max-w-[360px] mx-auto pt-60 flex flex-col items-center text-center">
       <CheckCircleIcon className="h-8" />
-      <h3>Your GitHub App has been installed!</h3>
+      <h3>Success!</h3>
       <p>
-        For security reasons your app will go through an additional approval
-        step before it is activated with Floe. This usually takes less than 24
-        hours.
+        For security reasons your installation will go through an additional
+        approval step before it is activated with Floe. This usually takes less
+        than 24 hours.
       </p>
     </div>
   );

--- a/apps/app/src/app/installation-confirmed/page.tsx
+++ b/apps/app/src/app/installation-confirmed/page.tsx
@@ -1,10 +1,14 @@
+import { CheckCircleIcon } from "@heroicons/react/24/solid";
+
 export default function Page() {
   return (
     <div className="px-4 prose prose-zinc sm:w-full sm:max-w-[360px] mx-auto pt-60 flex flex-col items-center">
+      <CheckCircleIcon className="h-8" />
+      <h3>Your GitHub App has been installed!</h3>
       <p>
-        Your GitHub App has been installed! For security reasons your app will
-        go through an additional approval step before it is activated with Floe.
-        This usually takes less than 24 hours.
+        For security reasons your app will go through an additional approval
+        step before it is activated with Floe. This usually takes less than 24
+        hours.
       </p>
     </div>
   );

--- a/apps/app/src/app/installation-confirmed/page.tsx
+++ b/apps/app/src/app/installation-confirmed/page.tsx
@@ -1,0 +1,11 @@
+export default function Page() {
+  return (
+    <div className="px-4 prose prose-zinc sm:w-full sm:max-w-[360px] mx-auto pt-60 flex flex-col items-center">
+      <p>
+        Your GitHub App has been installed! For security reasons your app will
+        go through an additional approval step before it is activated with Floe.
+        This usually takes less than 24 hours.
+      </p>
+    </div>
+  );
+}

--- a/apps/app/src/app/verify-request/page.tsx
+++ b/apps/app/src/app/verify-request/page.tsx
@@ -2,7 +2,7 @@ import { SparklesIcon } from "@heroicons/react/24/solid";
 
 export default function Page() {
   return (
-    <div className="px-4 prose prose-zinc sm:w-full sm:max-w-[360px] mx-auto pt-60 flex flex-col items-center">
+    <div className="px-4 prose prose-zinc sm:w-full sm:max-w-[360px] mx-auto pt-60 flex flex-col items-center text-center">
       <SparklesIcon className="h-8" />
       <p>A magic link has been sent to your email.</p>
     </div>

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -185,15 +185,23 @@ model Subscription {
     @@index([priceId])
 }
 
+enum IntegrationStatus {
+    pending
+    installed
+}
+
 model GithubIntegration {
-    id             String    @id @default(cuid())
-    workspace      Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-    workspaceId    String    @unique
-    installationId Int
-    createdAt      DateTime  @default(now())
-    updatedAt      DateTime  @updatedAt
+    id             String            @id @default(cuid())
+    workspace      Workspace         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+    workspaceId    String            @unique
+    installationId Int?
+    status         IntegrationStatus @default(installed)
+    owner          String?
+    createdAt      DateTime          @default(now())
+    updatedAt      DateTime          @updatedAt
 
     @@index([workspaceId])
+    @@index([owner])
 }
 
 model GitlabIntegration {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -191,13 +191,13 @@ enum IntegrationStatus {
 }
 
 model GithubIntegration {
-    id             String            @id @default(cuid())
-    workspace      Workspace         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
-    workspaceId    String            @unique
+    id             String    @id @default(cuid())
+    workspace      Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+    workspaceId    String    @unique
+    // If no installationId, the integration is pending approval.
     installationId Int?
-    status         IntegrationStatus @default(installed)
-    createdAt      DateTime          @default(now())
-    updatedAt      DateTime          @updatedAt
+    createdAt      DateTime  @default(now())
+    updatedAt      DateTime  @updatedAt
 
     @@index([workspaceId])
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -196,12 +196,10 @@ model GithubIntegration {
     workspaceId    String            @unique
     installationId Int?
     status         IntegrationStatus @default(installed)
-    owner          String?
     createdAt      DateTime          @default(now())
     updatedAt      DateTime          @updatedAt
 
     @@index([workspaceId])
-    @@index([owner])
 }
 
 model GitlabIntegration {


### PR DESCRIPTION
More gracefully handles the GitHub installation workflow for when a user goes through the GitHub integration flow and triggers an "Installation Request" on GitHub. This happens in situations where the requesting user does not have admin privileges in GitHub.

Unfortunately, this `request` flow is not yet well supported by GitHub:
https://github.com/orgs/community/discussions/42351

This means that it is not possible to store the installation on the workspace programmatically. Therefore, as a workaround this solution will send an email to me with the installation id. I can then manually authenticate the request and then update the workspace github integration with the `installationId` and set the `status` to `installed`.

In the future, this solution should be made programatic if GitHub indeed updates the request callback.